### PR TITLE
Improve design

### DIFF
--- a/submissions/fernando/index.html
+++ b/submissions/fernando/index.html
@@ -17,7 +17,7 @@
         <div class="main">
         </div>
         <div class="input">
-            <textarea id="messageInput" aria-label="Message input" placeholder="Type your message..." rows="5"></textarea>
+            <div id="messageInput" contenteditable="true" aria-label="Message input" placeholder-text="Type your message..."></div>
             <button id="sendButton" onclick="sendMessage()">Send</button>
         </div>
     </div>

--- a/submissions/fernando/script.js
+++ b/submissions/fernando/script.js
@@ -9,7 +9,7 @@ function refreshChat() {
     if (!confirm("Clear current chat?")) return;
 
     mainDiv.innerHTML = "";
-    messageInputElement.value = "";
+    messageInputElement.innerText = "";
     messageInputElement.focus();
 }
 
@@ -52,13 +52,13 @@ async function fetchOllamaAnswer(messages) {
 }
 
 async function sendMessage() {
-    const userMessage = messageInputElement.value.trim();
+    const userMessage = messageInputElement.innerText.trim();
     if (!userMessage) {
         console.log('Empty message...')
         return
     }
 
-    messageInputElement.value = "Thinking...";
+    messageInputElement.innerText = "Thinking...";
     messageInputElement.disabled = true;
     sendButtonElement.disabled = true;
 
@@ -73,7 +73,7 @@ async function sendMessage() {
     mainDiv.appendChild(Object.assign(document.createElement("div"), {innerText: aiAnswer, className: "message ai-answer"}));
     mainDiv.scrollTop = mainDiv.scrollHeight;
 
-    messageInputElement.value = "";
+    messageInputElement.innerText = "";
     messageInputElement.disabled = false;
     sendButtonElement.disabled = false;
     messageInputElement.focus();

--- a/submissions/fernando/styles.css
+++ b/submissions/fernando/styles.css
@@ -13,7 +13,7 @@ body {
 .navbar {
     background-color: black;
     height: 100vh;
-    width: 180px;
+    width: 8rem;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -34,8 +34,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 20vh;
-    margin-top: auto;
+    height: 10rem;
 }
 .refresh-btn {
     width: 48px;
@@ -61,8 +60,8 @@ body {
 .input {
     display: flex;
     align-items: center;
-    min-height: 20vh;
-    max-height: 20vh;
+    justify-content: center;
+    height: 12rem;
     position: sticky;
     bottom: 0;
 }
@@ -86,8 +85,8 @@ body {
 }
 #messageInput {
     width: 100%;
-    height: 80%;
-    margin: 16px;
+    height: 8rem;
+    margin: 1rem;
     padding: 8px;
     border: 2px solid;
     border-radius: 4px;
@@ -106,7 +105,7 @@ body {
     pointer-events: none;
 }
 #sendButton {
-    margin: 0px 20px 0px 10px;
+    margin-right: 1rem;
     padding: 0 22px;
     height: 42px;
     background: darkcyan;

--- a/submissions/fernando/styles.css
+++ b/submissions/fernando/styles.css
@@ -24,7 +24,7 @@ body {
     writing-mode: vertical-rl;
     color: white;
     font-size: 2.5rem;
-    letter-spacing: 0.4em;
+    letter-spacing: 1rem;
     font-weight: bold;
     flex: 1;
     display: flex;

--- a/submissions/fernando/styles.css
+++ b/submissions/fernando/styles.css
@@ -1,21 +1,24 @@
 body {
     display: flex;
     margin: 0;
+    overflow-x: hidden;
 }
 .main-wrapper{
     display: flex;
     flex-direction: column;
     width: 100%;
     height: 100vh;
+    min-width: 0;
 }
 .navbar {
     background-color: black;
     height: 100vh;
-    width: 200px;
+    width: 180px;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-direction: column;
+    flex-shrink: 0;
 }
 .vertical_title {
     writing-mode: vertical-rl;
@@ -59,6 +62,7 @@ body {
     display: flex;
     align-items: center;
     min-height: 20vh;
+    max-height: 20vh;
     position: sticky;
     bottom: 0;
 }
@@ -83,8 +87,23 @@ body {
 #messageInput {
     width: 100%;
     height: 80%;
-    margin: 10px;
+    margin: 16px;
+    padding: 8px;
+    border: 2px solid;
+    border-radius: 4px;
+    outline: none;
+    overflow-y: auto;
     resize: none;
+    box-sizing: border-box;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+/* placeholder */
+#messageInput:empty::before {
+    content: attr(placeholder-text);
+    color: #999;
+    pointer-events: none;
 }
 #sendButton {
     margin: 0px 20px 0px 10px;


### PR DESCRIPTION
@KakkoiDev , thanks for ir suggestions from PR https://github.com/KakkoiDev/izumo-io/pull/25
Based on your comments I've made some modfications as follow:
- [x] Applied `<div contenteditable="true">` to messageInput
- works when copying and pasting from formatted html text (but it does not allow formatting when typing)
- a few adaptations were necessary on javascript code and css to this new div works and displays properly
- [x] Changed **em** units to **rem**
- [x] Fixed height an units of some elements

Also I've made a few changes in order to avoid collapsing the design in some situations that I noticed, like:
- breaking line automatically instead of streching the input box width when having a long one word prompt
- allow vertical scroll of input box without extending input area height when having a prompt with many lines

【Demo】
https://github.com/user-attachments/assets/9818b9ff-62f3-4d22-a47b-e29416e9ab0e

